### PR TITLE
Remove JSONP from docs and add rate limit info

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ All endpoints require a valid API access token. Find out how to get one in the [
 
 > **Note**: It is not permitted to access our API directly from the browser, because this would expose your secret access token to the public. We are also rate limiting API calls, so calling the API from the browser will cause you to hit those rate limits very quickly. Frequent offenders are blocked from accessing the Walls.io API.
 
-> Instead, call the API from your server and cache the posts there. To avoid hitting any rate limits, make sure to not make more than 1 request per second.
+> Instead, call the API from your server and cache the posts there. To avoid hitting any rate limits, make sure to not make more than **1 request per access token per second**, and not more than **1 request per IP address per second**.
 
 
 All endpoints, if called with a `GET` request, support the following response formats:

--- a/README.md
+++ b/README.md
@@ -17,11 +17,13 @@ Walls.io API Documentation
 
 All endpoints require a valid API access token. Find out how to get one in the [FAQs].
 
+> **Note**: It is not permitted to access our API directly from the browser, because this would expose your secret access token to the public. We are also rate limiting API calls, so calling the API from the browser will cause you to hit those rate limits very quickly. Frequent offenders are blocked from accessing the Walls.io API.
+
+> Instead, call the API from your server and cache the posts there. To avoid hitting any rate limits, make sure to not make more than 1 request per second.
 
 
 All endpoints, if called with a `GET` request, support the following response formats:
 - **JSON**: Expample request: `api/posts.json`
-- **JSONP**: Like the JSON request, but pass a `callback` parameter, e.g.: `api/posts.json?callback=someCallbackName`
 - **XML**: Example request: `api/posts.xml`
 - **RSS**: Example request: `api/posts.rss` (This format is available on the posts-endpoint only!)
 

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Walls.io API Documentation
 
 All endpoints require a valid API access token. Find out how to get one in the [FAQs].
 
-> **Note**: It is not permitted to access our API directly from the browser, because this would expose your secret access token to the public. We are also rate limiting API calls, so calling the API from the browser will cause you to hit those rate limits very quickly. Frequent offenders are blocked from accessing the Walls.io API.
+> **Note**: It is not permitted to access our API directly from the browser, because this would expose your secret access token to the public. We are also rate limiting API calls, so calling the API from the browser will cause you to hit those rate limits very quickly.
 
-> Instead, call the API from your server and cache the posts there. To avoid hitting any rate limits, make sure to not make more than **1 request per access token per second**, and not more than **1 request per IP address per second**.
+> Instead, call the API from your server and cache the posts there.
 
 
 All endpoints, if called with a `GET` request, support the following response formats:


### PR DESCRIPTION
This PR removes all info about JSONP from the docs, because we will soon stop supporting JSONP in our API.

This also adds a paragraph about rate limits.
