### PR TITLE
Revert "[WI-2757] - converting the old highlighting to pinned to top docs"

### DIFF
--- a/Common_Post_Fields.md
+++ b/Common_Post_Fields.md
@@ -23,7 +23,7 @@ All responses from the `/posts` endpoints share the same set of fields:
 - `twitter_entities`: If the post type is `twitter`, this field contains an array of Twitter entities as received from the Twitter API.
 - `twitter_retweet`: If the post type is `twitter` and the post is a retweet, this field contains `true`.
 - `is_crosspost`: If this post was posted to multiple social networks at the same time, all posts that came after the original one contain `true` for this field. The original post contains `false`.
-- `is_pinned`: `true` if the post has been pinned to top by a moderator; `false` otherwise.
+- `is_highlighted`: `true` if the post has been highlighted by a moderator; `false` otherwise.
 - `status`: Whether this post is active (visible) or inactive (invisible) on the Wall. Contains `true` if it is active.
 - `created`: The date and time when this post was created in the social network it was posted to. The timezone is UTC.
 - `created_timestamp`: Same as `created`, but as a UNIX timestamp.

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Calling our API 1-2 times per second is fine.
   * [__GET__ `/posts/changed`](endpoints/GET_posts-changed.md) Get a list of posts, ordered by the time they were updated
   * [__GET__ `/posts/{postId}`](endpoints/GET_posts-postid.md) Get a single post
   * [__POST__ `/posts`](endpoints/POST_posts.md) Add a new Native Post
-  * [__PUT__ `/posts/{postId}`](endpoints/PUT_posts-postid.md) Change a single post's visibility status, pinned, language, or spam status
+  * [__PUT__ `/posts/{postId}`](endpoints/PUT_posts-postid.md) Change a single post's visibility status, highlighting, language, or spam status
 
 
 #### Post as RSS

--- a/endpoints/GET_analytics-posts.md
+++ b/endpoints/GET_analytics-posts.md
@@ -17,7 +17,7 @@ GET https://api.walls.io/v1/analytics/posts?access_token=<ACCESS_TOKEN>
 - `since`: Pass a UNIX timestamp to limit the result to posts that were posted after this time.
 - `media_types`: A comma-separated list of media types. Use this if you want to limit your query to text-only posts, or video posts, or image posts, or any combination of those. [Media Types]
 - `languages`: A comma-separated list of ISO 639-1 language codes. Only posts with a `comment` in one of these languages will be included in the response. [Languages]
-- `pinned_only`: Set this to `1` if you would only like to count posts that have been pinned to top by a moderator.
+- `highlighted_only`: Set this to `1` if you would only like to count posts that have been highlighted by a moderator.
 - `include_inactive`: Per default, only active posts are counted. If you want to receive all posts, regardless of status, set this to `1`.
 
 

--- a/endpoints/GET_analytics-users.md
+++ b/endpoints/GET_analytics-users.md
@@ -17,7 +17,7 @@ GET https://api.walls.io/v1/analytics/users?access_token=<ACCESS_TOKEN>
 - `since`: Pass a UNIX timestamp to limit the result to posts that were posted after this time.
 - `media_types`: A comma-separated list of media types. Use this if you want to limit your query to text-only posts, or video posts, or image posts, or any combination of those. [Media Types]
 - `languages`: A comma-separated list of ISO 639-1 language codes. Only posts with a `comment` in one of these languages will be included in the response. [Languages]
-- `pinned_only`: Set this to `1` if you would only like to count posts that have been pinned to top by a moderator.
+- `highlighted_only`: Set this to `1` if you would only like to count posts that have been highlighted by a moderator.
 - `include_inactive`: Per default, only active posts are counted. If you want to receive all posts, regardless of status, set this to `1`.
 
 ## Example response

--- a/endpoints/GET_posts-changed.md
+++ b/endpoints/GET_posts-changed.md
@@ -18,7 +18,7 @@ GET https://api.walls.io/v1/posts/changed?access_token=<ACCESS_TOKEN>&since=1404
 - `types`: A comma-separated list of the types of posts you would like to receive. [Post Types]
 - `media_types`: A comma-separated list of media types. Use this if you want to limit your query to text-only posts, or video posts, or image posts, or any combination of those. [Media Types]
 - `languages`: A comma-separated list of ISO 639-1 language codes. Only posts with a `comment` in one of these languages will be included in the response. [Languages]
-- `pinned_only`: Set this to `1` if you would only like to receive only posts that have been pinned to top by a moderator.
+- `highlighted_only`: Set this to `1` if you would only like to receive posts that have been highlighted by a moderator.
 - `include_inactive`: Per default, only active posts are returned. If you want to receive all posts, regardless of status, set this to `1`.
 - `include_source`: Set this to `1` if you want each post to include the source that it came from.
 
@@ -40,7 +40,7 @@ GET https://api.walls.io/v1/posts/changed?access_token=<ACCESS_TOKEN>&since=1404
       "external_post_id": "769415235382107591_372993670",
       "external_user_id": "372993670",
       "is_crosspost": false,
-      "is_pinned": false,
+      "is_highlighted": false,
       "permalink": "http:\/\/instagram.com\/p\/qtgxR9uV3H\/",
       "post_image": "http:\/\/scontent-a.cdninstagram.com\/hphotos-xfp1\/t51.2885-15\/10560907_307861969392635_1595149027_n.jpg",
       "post_link": "http:\/\/instagram.com\/p\/qtgxR9uV3H\/",

--- a/endpoints/GET_posts-changed.rss.md
+++ b/endpoints/GET_posts-changed.rss.md
@@ -13,7 +13,7 @@ Every time an existing post is updated, it rises to the top of this endpoint's r
 - `types`: A comma-separated list of the types of posts you would like to receive. [Post Types]
 - `media_types`: A comma-separated list of media types. Use this if you want to limit your query to text-only posts, or video posts, or image posts, or any combination of those. [Media Types]
 - `languages`: A comma-separated list of ISO 639-1 language codes. Only posts with a `comment` in one of these languages will be included in the response. [Languages]
-- `pinned_only`: Set this to `1` if you would only like to receive posts that have been pinned to top by a moderator.
+- `highlighted_only`: Set this to `1` if you would only like to receive posts that have been highlighted by a moderator.
 - `include_inactive`: Per default, only active posts are returned. If you want to receive all posts, regardless of status, set this to `1`.
 - `include_source`: Set this to `1` if you want each post to include the source that it came from.
 

--- a/endpoints/GET_posts-postid.md
+++ b/endpoints/GET_posts-postid.md
@@ -41,7 +41,7 @@ GET https://api.walls.io/v1/posts/17181206?access_token=<ACCESS_TOKEN>
     "post_video":null,
     "twitter_entities": null,
     "twitter_retweet": false,
-    "is_pinned": false,
+    "is_highlighted": false,
     "status": true,
     "location": null,
     "latitude": "51.48247833300000",

--- a/endpoints/GET_posts.md
+++ b/endpoints/GET_posts.md
@@ -19,7 +19,7 @@ However, this order of posts is usually not what you want to display in your fro
 - `types`: A comma-separated list of the types of posts you would like to receive. [Post Types]
 - `media_types`: A comma-separated list of media types. Use this if you want to limit your query to text-only posts, or video posts, or image posts, or any combination of those. [Media Types]
 - `languages`: A comma-separated list of ISO 639-1 language codes. Only posts with a `comment` in one of these languages will be included in the response. [Languages]
-- `pinned_only`: Set this to `1` if you would only like to receive posts that have been pinned to top by a moderator.
+- `highlighted_only`: Set this to `1` if you would only like to receive posts that have been highlighted by a moderator.
 - `include_inactive`: Per default, only active posts are returned. If you want to receive all posts, regardless of status, set this to `1`.
 - `include_source`: Set this to `1` if you want each post to include the source that it came from.
 - `sort`: Order the result by any field, according to the [JSON:API specification]. You may provide several comma-separated fields. The sort order is ascending unless it's prefixed with a minus, in which case it is descending. E.g. `?sort=-external_fullname,comment` first sort by `external_fullname` in descending order, then by `comment` in ascending order. Default: `-id`.
@@ -55,7 +55,7 @@ GET https://api.walls.io/v1/posts?access_token=<ACCESS_TOKEN>&fields=id,comment,
       "post_video":null,
       "twitter_entities":"{\"hashtags\":[{\"text\":\"Starbucks\",\"indices\":[14,24]},{\"text\":\"feinding\",\"indices\":[27,36]}],\"trends\":[],\"urls\":[],\"user_mentions\":[],\"symbols\":[]}",
       "twitter_retweet":false,
-      "is_pinned":false,
+      "is_highlighted":false,
       "status":true,
       "created":"2014-07-10 14:35:38",
       "modified":"2014-07-10 14:35:39",
@@ -78,7 +78,7 @@ GET https://api.walls.io/v1/posts?access_token=<ACCESS_TOKEN>&fields=id,comment,
       "post_video":null,
       "twitter_entities":"{\"hashtags\":[{\"text\":\"starbucks\",\"indices\":[13,23]},{\"text\":\"howard\",\"indices\":[35,42]},{\"text\":\"thatsnotmyname\",\"indices\":[46,61]},{\"text\":\"starbucksfail\",\"indices\":[62,76]}],\"trends\":[],\"urls\":[],\"user_mentions\":[],\"symbols\":[]}",
       "twitter_retweet":false,
-      "is_pinned":false,
+      "is_highlighted":false,
       "status":true,
       "created":"2014-07-10 14:34:57",
       "modified":"2014-07-10 14:34:57",

--- a/endpoints/GET_posts.rss.md
+++ b/endpoints/GET_posts.rss.md
@@ -23,7 +23,7 @@ GET https://api.walls.io/v1/posts.rss?access_token=<ACCESS_TOKEN>`
 - `types`: A comma-separated list of the types of posts you would like to receive. [Post Types]
 - `media_types`: A comma-separated list of media types. Use this if you want to limit your query to text-only posts, or video posts, or image posts, or any combination of those. [Media Types]
 - `languages`: A comma-separated list of ISO 639-1 language codes. Only posts with a `comment` in one of these languages will be included in the response. [Languages]
-- `pinned_only`: Set this to `1` if you would only like to receive only posts that have been pinned to top by a moderator.
+- `highlighted_only`: Set this to `1` if you would only like to receive posts that have been highlighted by a moderator.
 - `include_inactive`: Per default, only active posts are returned. If you want to receive all posts, regardless of status, set this to `1`.
 - `include_source`: Set this to `1` if you want each post to include the source that it came from.
 

--- a/endpoints/POST_posts.md
+++ b/endpoints/POST_posts.md
@@ -40,7 +40,7 @@ curl -X POST \
 - `latitude`: Latitude of the location where this post was created, as a `float`, e.g. `48.208`
 - `longitude`: Longitude of the location where this post was created, as a `float`, e.g. `16.367`
 - `scheduled_timestamp`: If set, the post is not added to the Wall's frontend right away but scheduled to be posted later. Must be a UNIX timestamp in seconds and must not be in the past.
-- `is_pinned`: Set this to `1` if the post should be pinned to top.
+- `is_highlighted`: Set this to `1` if the post should be highlighted.
 - `status`: Set this to `1` or `0` to force the visibility (a.k.a. "status") of the new post. Usually the status is determined by checking the post against the language filter, spam filter, and several blacklists and whitelists. All of those checks can be bypassed by explicitly setting the `status` field in this call.
 
 

--- a/endpoints/PUT_posts-postid.md
+++ b/endpoints/PUT_posts-postid.md
@@ -1,6 +1,6 @@
 # PUT `/posts/{postId}`
 
-#### Change a single post's visibility status, pinned, language, or spam status
+#### Change a single post's visibility status, highlighting, language, or spam status
 
 The post is identified by its Walls.io post id.
 
@@ -14,12 +14,12 @@ You can perform multiple actions at once by setting multiple parameters.
 curl -X PUT \
   https://api.walls.io/v1/posts/17181206 \
   -H 'content-type: application/x-www-form-urlencoded' \
-  -d 'access_token=<ACCESS_TOKEN>&is_pinned=1&status=1&language=en'
+  -d 'access_token=<ACCESS_TOKEN>&is_highlighted=1&status=1&language=en'
 ```
 
 ## Parameters
 - `access_token` *(required)*: Your Walls.io access token.
-- `is_pinned`: Set this to `1` if the post should be pinned to top, or `0` to remove that flag flag.
+- `is_highlighted`: Set this to `1` if the post should be highlighted, or `0` to remove an existing highlight flag.
 - `status`: Set this to `1` to show a hidden post, or `0` to hide a visible post.
 - `language`: Set this to change the language of a post. The language is passed as a two-letter ISO 639-1 language code. You can also remove a post's language completely by passing an empty string. To find out which languages are supported by the Walls.io API simply set this to a random value; the response will contain a list of all valid language codes.
 - `report_spam`: Set this to `1` to report this post for spam, or `0` to remove the spam status from a post that was incorrectly reported as spam.


### PR DESCRIPTION
Reverts DieSocialisten/Walls.io-API-Docs#26

Merged the PR too early - should have been merged only after we deploy the pinned to top to production.